### PR TITLE
Add automated mode for Diabeloop Device

### DIFF
--- a/js/data/util/constants.js
+++ b/js/data/util/constants.js
@@ -9,13 +9,16 @@ const MGDL_PER_MMOLL = 18.01559;
 module.exports = {
   AUTOMATED_BASAL_DEVICE_MODELS: {
     Medtronic: ['1780'],
+    Diabeloop: ['DBLG1'],
   },
   AUTOMATED_BASAL_LABELS: {
     Medtronic: t('Auto Mode'),
+    Diabeloop: t('Closed Loop'),
     default: t('Automated'),
   },
   SCHEDULED_BASAL_LABELS: {
     Medtronic: t('Manual'),
+    Diabeloop: t('Open Loop'),
     default: t('Manual'),
   },
   MGDL_PER_MMOLL,

--- a/test/constants_test.js
+++ b/test/constants_test.js
@@ -42,12 +42,14 @@ describe('constants', function() {
   it('should define the AUTOMATED_BASAL_DEVICE_MODELS mapping', function() {
     expect(constants.AUTOMATED_BASAL_DEVICE_MODELS).to.eql({
       Medtronic: ['1780'],
+      Diabeloop: ['DBLG1'],
     });
   });
 
   it('should define the AUTOMATED_BASAL_LABELS mapping', function() {
     expect(constants.AUTOMATED_BASAL_LABELS).to.eql({
       Medtronic: 'Auto Mode',
+      Diabeloop: 'Closed Loop',
       default: 'Automated',
     });
   });
@@ -55,6 +57,7 @@ describe('constants', function() {
   it('should define the SCHEDULED_BASAL_LABELS mapping', function() {
     expect(constants.SCHEDULED_BASAL_LABELS).to.eql({
       Medtronic: 'Manual',
+      Diabeloop: 'Open Loop',
       default: 'Manual',
     });
   });


### PR DESCRIPTION
This one is to make sure we can distinguish our automatic mode with from other manufacturers. The 'Closed Loop' and 'Open Loop' keywords can be translated/replaced with other wording in translation files.